### PR TITLE
Fix pip PATH for running container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,8 @@
 FROM quay.io/bedrock/ubuntu:20.04
 
+# make sure non-root pip installed binaries are on the user's path
+ENV PATH="${PATH}:~/.local/bin"
+
 RUN apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
     apt-transport-https \
@@ -31,8 +34,6 @@ RUN ln -s pip3 /usr/bin/pip
 
 ADD requirements.txt /tmp/requirements.txt
 ADD constraints.txt /tmp/constraints.txt
-
-RUN sed 's|"$|:~/.local/bin"|' -i /etc/environment  # make sure non-root pip installed binaries are on the user's path
 
 RUN pip install \
     -r /tmp/requirements.txt \


### PR DESCRIPTION
The env vars in `/etc/environment` are not loaded when Azure Pipelines runs the tests in the container so `~/.local/bin` is not in the PATH causing failures when trying to invoke `ansible-test`. Instead just always add `~/.local/bin` to the path using the Dockerfile `ENV` entry.

This has been tested with https://github.com/ansible-collections/ansible.windows/pull/155. The run results are https://dev.azure.com/ansible/ansible.windows/_build/results?buildId=2162&view=results.

Also running it locally has the `PATH` env set with `~/.local/bin` appended to the end.