### PR TITLE
Switch back to Ubuntu 20.04.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,16 @@
-FROM quay.io/bedrock/ubuntu:jammy-20220428
+FROM quay.io/bedrock/ubuntu:focal-20220531
 
 # make sure non-root pip installed binaries are on the user's path
 ENV PATH="${PATH}:~/.local/bin"
 
 RUN apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-    apt-transport-https \
     curl \
     docker.io \
     git \
     openssh-client \
-    python-is-python3 \
-    python3 \
     python3-pip \
-    python3-venv \
+    python3.9-venv \
     sudo \
     && \
     apt-get clean && \
@@ -21,6 +18,9 @@ RUN apt-get update -y && \
 
 ADD requirements.txt /tmp/requirements.txt
 ADD constraints.txt /tmp/constraints.txt
+
+RUN ln -sf python3.9 /usr/bin/python3
+RUN ln -sf python3 /usr/bin/python
 
 RUN pip install \
     -r /tmp/requirements.txt \

--- a/constraints.txt
+++ b/constraints.txt
@@ -1,9 +1,9 @@
 cffi==1.15.0
-cryptography==36.0.2
-Jinja2==3.1.1
+cryptography==37.0.2
+Jinja2==3.1.2
 MarkupSafe==2.1.1
 packaging==21.3
 pycparser==2.21
-pyparsing==3.0.8
+pyparsing==3.0.9
 PyYAML==6.0
 resolvelib==0.5.4


### PR DESCRIPTION
* Use Python 3.9 instead of Python 3.10.
* Update frozen requirements.

These changes will allow ansible-core 2.11+ to be supported.