### PR TITLE
Make Python 3.10 default in the container image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/bedrock/ubuntu:focal-20220531
+FROM quay.io/bedrock/ubuntu:jammy-20230425
 
 # make sure non-root pip installed binaries are on the user's path
 ENV PATH="${PATH}:~/.local/bin"
@@ -10,7 +10,7 @@ RUN apt-get update -y && \
     git \
     openssh-client \
     python3-pip \
-    python3.9-venv \
+    python3.10-venv \
     sudo \
     && \
     apt-get clean && \
@@ -18,9 +18,6 @@ RUN apt-get update -y && \
 
 ADD requirements.txt /tmp/requirements.txt
 ADD constraints.txt /tmp/constraints.txt
-
-RUN ln -sf python3.9 /usr/bin/python3
-RUN ln -sf python3 /usr/bin/python
 
 RUN pip install \
     -r /tmp/requirements.txt \

--- a/constraints.txt
+++ b/constraints.txt
@@ -1,9 +1,8 @@
-cffi==1.15.0
-cryptography==37.0.2
+cffi==1.15.1
+cryptography==40.0.2
 Jinja2==3.1.2
-MarkupSafe==2.1.1
-packaging==21.3
+MarkupSafe==2.1.2
+packaging==23.1
 pycparser==2.21
-pyparsing==3.0.9
 PyYAML==6.0
 resolvelib==0.5.4


### PR DESCRIPTION
This also updates the base image to use Ubuntu 22.04 Jammy in place of the previously used Ubuntu 20.04 Focal.

Ref: https://github.com/ansible/ansible/issues/80424