### PR TITLE
Symlink the `python` executable to be `python3`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ RUN apt-get update -y && \
     docker.io \
     git \
     openssh-client \
+    python-is-python3 \
     python3-pip \
     python3.10-venv \
     sudo \


### PR DESCRIPTION
This is necessary since PEP 394 recommends the downstream systems to point the unversioned `python` to `python2` only or remove it [[1]]. By now, despite the perceived controversy[[2]], many distros obliged and stopped adding `python` executable by default while still allowing to customize it.

We've decided to have it pointing to `python3` hoping this would make compatibility easier.

[1]: https://peps.python.org/pep-0394/
[2]: https://lwn.net/Articles/780737/